### PR TITLE
Add workflow parameter to inputs list

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This action cancels previous runs for one or more branches/prs associated with a
 
 ## Usage
 
-The easiest and most complete approach to utilize this action, is to create a separate schedule event triggered workflow, which is directed at the workflow you wish to clear duplicate runs. At each cron interrval all branches and all PRs executing for either push or pull_request events will be processed and limited to one run per branch/pr. 
+The easiest and most complete approach to utilize this action, is to create a separate schedule event triggered workflow, which is directed at the workflow you wish to clear duplicate runs. At each cron interval all branches and all PRs executing for either push or pull_request events will be processed and limited to one run per branch/pr.
 
 Additionally this action can be placed as an early step in your workflow (e.g. after checkout), so that it can abort the other previously running jobs immediately, in case most resources are tied up. Unfortunately this approach is a no-op when a pull request uses a fork for a source branch. This is because the GITHUB_TOKEN provided to runs with a fork source branch specifies reed-only permissions for security reasons. write permissions are required to be able to cancel a job. Therefore, it's a good idea to only rely on this approach as a fallback in-addition to the previously described scheduling model. 
 

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   token:
     description: The GITHUB_TOKEN secret of this github workflow
     required: true
+  workflow:
+    description: The filename of the workflow to limit runs on (only applies to schedule events)
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,7 @@ async function cancelDuplicates(
 ): Promise<void> {
   const octokit = new github.GitHub(token)
 
-  // Deteermind the workflow to reduce the result set, or reference anothre workflow
+  // Determine the workflow to reduce the result set, or reference another workflow
   let resolvedId = ''
   if (workflowId === undefined) {
     const reply = await octokit.actions.getWorkflowRun({


### PR DESCRIPTION
Fixes up `Unexpected input 'workflow', valid inputs are ['token']` warning when viewing workflow runs.