### PR TITLE
Include the event that triggered a particular run of a target job

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -96,7 +96,7 @@ async function cancelDuplicates(
   for (const entry of sorted.backward()) {
     const element = entry[1]
     core.info(
-      `${element.id} : ${element.workflow_url} : ${element.status} : ${element.run_number}`
+      `${element.id} : ${element.event} : ${element.workflow_url} : ${element.status} : ${element.run_number}`
     )
 
     if (!matched) {


### PR DESCRIPTION
A minor change to log the `event` which triggered the job that might be selected for cancellation. This would provide a bit more information on why a particular job could have been selected for cancellation.