### PR TITLE
Import Octokit as a single export

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import * as github from '@actions/github'
 import * as core from '@actions/core'
-import Octokit from '@octokit/rest'
+import { Octokit } from '@octokit/rest'
 import * as treemap from 'jstreemap'
 
 function createRunsQuery(


### PR DESCRIPTION
Getting rid of deprecation warning:
```
[@octokit/rest] `const Octokit = require("@octokit/rest")` is deprecated. Use `const { Octokit } = require("@octokit/rest")` instead
```